### PR TITLE
Add User-Agent header and restriction on installing futures

### DIFF
--- a/mwviews/api/pageviews.py
+++ b/mwviews/api/pageviews.py
@@ -36,14 +36,21 @@ def month_from_day(dt):
 
 class PageviewsClient:
 
-    def __init__(self, parallelism=10):
+    def __init__(self, user_agent, parallelism=10):
         """
         Create a PageviewsClient
 
         :Parameters:
+            user_agent : User-Agent string to use for HTTP requests. Should be
+                         set to something that allows you to be contacted if
+                         need be, ref:
+                         https://www.mediawiki.org/wiki/REST_API
+
             parallelism : The number of parallel threads to use when making
                           multiple requests to the API at the same time
         """
+
+        self.headers = {"User-Agent": user_agent}
         self.parallelism = parallelism
 
     def article_views(
@@ -293,7 +300,7 @@ class PageviewsClient:
         url = '/'.join([endpoints['top'], project, access, year, month, day])
 
         try:
-            result = requests.get(url).json()
+            result = requests.get(url, headers=self.headers).json()
 
             if 'items' in result and len(result['items']) == 1:
                 r = result['items'][0]['articles']
@@ -310,5 +317,5 @@ class PageviewsClient:
 
     def get_concurrent(self, urls):
         with ThreadPoolExecutor(self.parallelism) as executor:
-            f = lambda url: requests.get(url).json()
+            f = lambda url: requests.get(url, headers=self.headers).json()
             return list(executor.map(f, urls))

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     download_url='https://github.com/mediawiki-utilities/python-mwviews/tarball/0.0.9',
     packages=find_packages(),
     keywords=['wikimedia', 'wikipedia', 'pageview', 'api'],
-    install_requires=['requests', 'futures']
+    install_requires=['requests', 'futures;python_version<"3.0"']
 )


### PR DESCRIPTION
The API spec asks that the user set a meaningful User-Agent header, so I changed the constructor to reflect that by requiring a user-agent string (and referring to the wiki for more information).

When installing this library on Python 3 it also wants to install futures, which isn't necessary (meaning it'll have to manually be uninstalled afterwards). The suggested change to setup.py allows for this but  require an updated version of setuptools. Not sure if there are "nicer" ways of doing this, from what I could find there are ways to check the Python version during install but they also come with caveats.