### PR TITLE
Use the API for granularity='monthly'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ p = PageviewsClient()
 p.article_views('en.wikipedia', ['Selfie', 'Cat', 'Dog'])
 p.project_views(['ro.wikipedia', 'de.wikipedia', 'commons.wikimedia'])
 p.top_articles('en.wikipedia', limit=10)
-
-# The client can do more than the API, for example monthly rollups for article views:
-p.article_views('en.wikipedia', ['Selfie', 'Cat'], granularity='monthly', start='2016020100', end='2016043000')
+p.article_views('en.wikipedia', ['Selfie', 'Cat'], granularity='monthly', start='20160201', end='20160331')
 
 # Feel free to add your own features in pull requests!
 ```

--- a/mwviews/api/pageviews.py
+++ b/mwviews/api/pageviews.py
@@ -125,11 +125,7 @@ class PageviewsClient:
 
         outputDays = timestamps_between(startDate, endDate, timedelta(days=1))
         if granularity == 'monthly':
-            outputMonths = set()
-            for day in outputDays:
-                month = month_from_day(day)
-                outputMonths.add(month)
-                outputDays = list(outputMonths)
+            outputDays = list(set([month_from_day(day) for day in outputDays]))
         output = defaultdict(dict, {
             day: {a: None for a in articles} for day in outputDays
         })


### PR DESCRIPTION
Fixed issue #12: use the API for monthly granularity, instead of doing client-side aggregation.