### PR TITLE
Adding all-agents as default

### DIFF
--- a/mwviews/api/pageviews.py
+++ b/mwviews/api/pageviews.py
@@ -35,7 +35,7 @@ def month_from_day(dt):
 
 
 class PageviewsClient:
-    def __init__(self, user_agent, parallelism=10):
+    def __init__(self, user_agent='all-agents', parallelism=10):
         """
         Create a PageviewsClient
 


### PR DESCRIPTION
to init  PageviewsClient() an user-agent is required, giving an error if you follow the README instructions.

I'm adding all-agents as defaults 